### PR TITLE
feat: 实时更新歌词+状态栏显示时间

### DIFF
--- a/similubot/playback/playback_event.py
+++ b/similubot/playback/playback_event.py
@@ -137,11 +137,7 @@ class PlaybackEvent:
 
             # 设置频道状态
             try:
-                route = discord.http.Route("PUT", "/channels/{channel_id}/voice-status", channel_id=channel_id)
-                payload = {
-                    "status": f"🎵 {song.title}"
-                }
-                ret = await channel._state.http.request(route, json=payload)
+                await channel.edit(status=f"🎵 {song.title}")
                 self.logger.info(f"✅ 频道状态设置成功 - {song.title}")
             except Exception as e:
                 self.logger.warning(f"⚠️ 设置频道状态失败: {e}")


### PR DESCRIPTION
此PR实现以下两个功能：
- 在频道状态处显示当前播放进度
- 在播放到新的歌词时实时更新歌词embed

技术细节：
- discord api并没有10分钟120次的严苛限制，实时更新歌词所需的请求频率对真实的rate limit来说完全属于超低频，所以没有必要强制等待5秒再更新歌词，而是可以随着歌曲实时更新
- 设置频道状态从直接的http请求替换为了更稳健的discord.py api实现

实现细节：
- 保留了interval_lyrics以防万一
- 没有被跳过的歌词时，以斜体显示前一行歌词

效果图：
<img width="497" height="425" alt="image" src="https://github.com/user-attachments/assets/99b48f55-81cc-4043-b1ee-558ce2448dcf" />
<img width="393" height="151" alt="image" src="https://github.com/user-attachments/assets/88fd0873-31c5-43fc-bad8-b7021cace95f" />
